### PR TITLE
refactor(box_traits): require explicit specialization to opt in as a box

### DIFF
--- a/docs/design_rationale.md
+++ b/docs/design_rationale.md
@@ -127,14 +127,24 @@ Most real types already expose part of this interface. The library runs a deduct
 for each capability: it checks the explicit specialization first, then the box type's own
 members, then the template parameters. You only need to supply what it cannot find on its own.
 
-### When everything is deducible — no specialization needed
+### When everything is deducible — empty opt-in
+
+Opting a type into the box abstraction is always explicit: a `box_traits<T>` specialization is
+required even if the type already exposes a fully compatible interface. This prevents types from
+being silently treated as boxes with incorrect behaviour — for example, a type that satisfies
+almost everything but lacks `make_error` would otherwise be accepted and produce wrong results.
 
 `std::expected<T, E>` already has `has_value()`, `value()`, `error()`, nested `value_type`
 and `error_type`, and two template parameters that the library uses for rebind deduction.
-The default `box_traits<T>` is an empty struct, so no specialization is required — the
-deduction cascade reads everything directly from the type's own members.
+An empty specialization is the minimal opt-in; the deduction cascade then reads everything
+directly from the type's own members:
 
-All four operations work immediately without any `box_traits` specialization.
+```cpp
+template <typename T, typename E>
+struct beman::monadics::box_traits<std::expected<T, E>> {};
+```
+
+All four operations are available immediately after this opt-in.
 
 ### When a few pieces are missing — minimal specialization
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -20,21 +20,32 @@ header for the box type being demonstrated.
 
 ## Opting In a Type
 
-A type becomes a box once the library can resolve its `box_traits<T>`. For well-structured
-types this requires no specialization at all; for others, only the missing pieces need to be
-provided.
+Opting a type into the box abstraction is explicit: you must specialize
+`beman::monadics::box_traits<T>`, even if the type already exposes a fully compatible interface.
+This prevents types from being silently treated as boxes with incorrect behaviour.
 
-### Case 1: Auto-deduction (no specialization needed)
+An empty specialization is the minimum required opt-in. Once opted in, any members the type
+already exposes are deduced automatically; you only need to supply what is missing.
+
+### Case 1: Empty opt-in (well-structured types)
 
 If the type already exposes a compatible interface — member `has_value()`, `value()`, `error()`,
-nested `value_type` / `error_type`, and `rebind` / `rebind_error` — no specialization is needed.
-The library deduces everything automatically.
+nested `value_type` / `error_type`, and `rebind` / `rebind_error` — an empty specialization is
+all that is needed. The library deduces everything else automatically.
 
-`std::expected` is the canonical example. All four operations are immediately available:
+`std::expected` is the canonical example. Opt in with an empty specialization and all four
+operations become available:
 
 ```cpp
+#include <beman/monadics/monadics.hpp>
 #include <expected>
 #include <string>
+
+template <typename T, typename E>
+struct beman::monadics::box_traits<std::expected<T, E>> {};
+```
+
+```cpp
 using E = std::expected<int, std::string>;
 
 auto result =

--- a/include/beman/monadics/detail/box_traits.hpp
+++ b/include/beman/monadics/detail/box_traits.hpp
@@ -3,10 +3,16 @@
 #ifndef BEMAN_MONADICS_DETAIL_BOX_TRAITS_HPP
 #define BEMAN_MONADICS_DETAIL_BOX_TRAITS_HPP
 
+#include <beman/monadics/detail/utility.hpp>
+
 namespace beman::monadics::detail {
 
 template<typename T>
-struct box_traits {};
+struct box_traits;
+
+template<typename T>
+concept has_box_traits =
+    requires { sizeof(box_traits<T>) >= std::size_t{}; } || on_error<"Missing explicit box_traits<T> specialization">;
 
 } // namespace beman::monadics::detail
 

--- a/include/beman/monadics/detail/get_box_traits.hpp
+++ b/include/beman/monadics/detail/get_box_traits.hpp
@@ -21,7 +21,8 @@ namespace beman::monadics::detail {
 namespace _get_box_traits {
 
 template<typename Box, typename Traits>
-concept box = has_value_type<Box, Traits>
+concept box = has_box_traits<Box>
+           && has_value_type<Box, Traits>
            && has_error_type<Box, Traits>
            && has_rebind<Box, Traits, get_value_type_t<Box, Traits>>
            && has_rebind_error<Box, Traits, get_error_type_t<Box, Traits>>

--- a/tests/beman/monadics/detail/CMakeLists.txt
+++ b/tests/beman/monadics/detail/CMakeLists.txt
@@ -6,6 +6,7 @@ add_dependencies(${test_global_target} ${test_dir_target})
 
 set(tests
     as_pointer
+    box_traits
     decomposable
     get_error_fn
     get_error_type

--- a/tests/beman/monadics/detail/box_traits.test.cpp
+++ b/tests/beman/monadics/detail/box_traits.test.cpp
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <beman/monadics/detail/box_traits.hpp>
+
+#include <catch2/catch_template_test_macros.hpp>
+
+struct NoSpecialization {};
+
+struct EmptySpecialization {};
+
+template<>
+struct beman::monadics::detail::box_traits<EmptySpecialization> {};
+
+struct NonEmptySpecialization {};
+
+template<>
+struct beman::monadics::detail::box_traits<NonEmptySpecialization> {
+    using value_type = int;
+};
+
+namespace beman::monadics::detail::tests {
+
+TEMPLATE_TEST_CASE_SIG("concept",
+                       "",
+                       ((typename T, bool Result), T, Result),
+                       (NoSpecialization, false),
+                       (EmptySpecialization, true),
+                       (NonEmptySpecialization, true)) {
+    STATIC_REQUIRE(has_box_traits<T> == Result);
+}
+
+} // namespace beman::monadics::detail::tests

--- a/tests/beman/monadics/result/trait.hpp
+++ b/tests/beman/monadics/result/trait.hpp
@@ -99,4 +99,7 @@ class [[nodiscard("Result value should be handled")]] Result {
     bool has_value_{false};
 };
 
+template<typename T, typename E>
+struct beman::monadics::box_traits<Result<T, E>> {};
+
 #endif // BEMAN_MONADICS_RESULT_TRAIT_HPP


### PR DESCRIPTION
Adapting a type is now an explicit opt-in via box_traits specialization. This prevents types from being silently accepted with incorrect behavior. For example std::expected without make_error would construct wrong boxes.

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
