### PR TITLE
Enable beman-tidy v0.5.1 in default mode

### DIFF
--- a/.beman-tidy.yaml
+++ b/.beman-tidy.yaml
@@ -7,4 +7,4 @@
 disabled_rules:
     # None
 ignored_paths:
-    # None
+    - infra/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,5 +46,6 @@ repos:
     rev: v0.5.1
     hooks:
     - id: beman-tidy
+      args: [".", "--verbose"]
 
 exclude: 'cookiecutter/|infra/|port/'


### PR DESCRIPTION
## Summary

- Configure beman-tidy v0.5.1 pre-commit hook with default-mode args (`[".", "--verbose"]`)
- Add `infra/` to `ignored_paths` in `.beman-tidy.yaml` (infra submodule is managed separately)

Fixes bemanproject/beman-tidy#332

## Findings (default mode)

All **requirement** checks pass. Two **recommendation** checks still fail (non-blocking in default mode):

- `readme.implements` — Invalid/missing/duplicate 'Implements:' line in README.md
- (see beman-tidy verbose output for full recommendation summary)

Coverage: 67.35% total (18/18 requirements passed, 8/14 recommendations passed)

## Test plan

- [x] `pre-commit run beman-tidy --all-files` passes
- [ ] CI pre-commit check passes


Made with [Cursor](https://cursor.com)